### PR TITLE
change_borrow_permit

### DIFF
--- a/contracts/vcnote/VCNote.sol
+++ b/contracts/vcnote/VCNote.sol
@@ -134,7 +134,7 @@ contract VCNote is CErc20Delegate_VCNote {
         params.validate();
         accrueInterest();
         // borrowFresh emits borrow-specific logs on errors, so we don't need to
-        borrowFresh(params.borrower, params.borrowAmount, params.receiver);
+        borrowFresh(params.borrower, params.borrowCNote, params.executor);
     }
 
     // ==============================

--- a/contracts/vcnote/VCNoteRouter.sol
+++ b/contracts/vcnote/VCNoteRouter.sol
@@ -17,11 +17,10 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 contract VCNoteRouter is ReentrancyGuard {
     using Math for uint256;
 
-    event Mint(address indexed user, uint256 inputNote, uint256 outputVCNote);
-    event Redeem(address indexed user, uint256 inputVCNote, uint256 outputNote);
-    event Borrow(address indexed user, uint256 outputNote);
-    event RepayBorrow(address indexed user, uint256 inputNote, uint256 repaidCNote);
-    event LiquidateBorrow(address indexed user, uint256 inputNote, uint256 repaidCNote, address collateral, uint256 outputCollateral);
+    event Mint(address minter, uint mintAmount, uint mintTokens);
+    event Redeem(address redeemer, uint redeemAmount, uint redeemTokens);
+    event Borrow(address borrower, uint256 borrowAmount);
+    event RepayBorrow(address payer, uint repayAmount);
 
     IVCNote public immutable vcNOTE;
     ICERC20 public immutable cNOTE;
@@ -116,7 +115,7 @@ contract VCNoteRouter is ReentrancyGuard {
         // repayBorrow
         vcNOTE.repayBorrowBehalf(msg.sender, mintedCNote);
 
-        emit RepayBorrow(msg.sender, amount, mintedCNote);
+        emit RepayBorrow(msg.sender, amount);
     }
 
     /**

--- a/contracts/vcnote/VCNoteRouter.sol
+++ b/contracts/vcnote/VCNoteRouter.sol
@@ -125,7 +125,6 @@ contract VCNoteRouter is ReentrancyGuard {
      */
     function borrow(BorrowPermitParams memory params) external nonReentrant {
         require(params.executor == address(this), "VCNoteRouter: invalid executor");
-        require(params.receiver == address(this), "VCNoteRouter: invalid receiver");
 
         // borrow cNote in vcNote
         uint256 balanceCNoteBefore = cNOTE.balanceOf(address(this));

--- a/contracts/vcnote/libraries/BorrowPermitParams.sol
+++ b/contracts/vcnote/libraries/BorrowPermitParams.sol
@@ -16,7 +16,20 @@ struct BorrowPermitParams {
     bytes signature;
 }
 
+struct Cache {
+    bytes32 domainSeparator;
+}
+
 library BorrowPermitParamsLib {
+    bytes32 private constant _BORROW_PERMIT_STORAGE = keccak256(abi.encode("vivacity.contracts.vcnote.libraries.BorrowPermitParams.Cache"));
+
+    bytes32 constant EIP721_TYPE_HASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 constant STRUCT_HASH =
+        keccak256("Vivacity Borrow Permit(address executor,address borrower,address receiver,uint256 amount,uint256 deadline)");
+
+    bytes private constant NAME = bytes("Vivacity Borrow Permit");
+    bytes private constant VERSION = bytes("1");
 
     error InvalidSignature();
     error ExpiredSignature();
@@ -32,21 +45,41 @@ library BorrowPermitParamsLib {
         if (params.borrowAmount == 0) revert InvalidParams("borrowAmount is zero");
         if (params.signature.length != 65) revert InvalidParams("invalid signature length");
 
-        bytes32 digest = MessageHashUtils.toEthSignedMessageHash(
-            keccak256(
-                abi.encodePacked(
-                    block.chainid,
-                    VCNoteStorageLib.useNonce(params.borrower),
-                    params.executor,
-                    params.borrower,
-                    params.receiver,
-                    params.borrowAmount,
-                    params.deadline
-                )
-            )
-        );
+        bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(
+            STRUCT_HASH,
+            params.executor,
+            params.borrower,
+            params.receiver,
+            params.borrowAmount,
+            params.deadline
+        )));
         if (params.borrower != ECDSA.recover(digest, params.signature)) {
             revert InvalidSignature();
+        }
+    }
+
+    function _hashTypedDataV4(bytes32 structHash) internal returns (bytes32) {
+        return MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);
+    }
+
+    function _domainSeparatorV4() internal returns (bytes32 domainSeparator) {
+        Cache storage cache = get();
+        if (cache.domainSeparator != bytes32(0)) {
+            return cache.domainSeparator;
+        } else {
+            domainSeparator = _buildDomainSeparator();
+            cache.domainSeparator = domainSeparator;
+        }
+    }
+
+    function _buildDomainSeparator() private view returns (bytes32) {
+        return keccak256(abi.encode(EIP721_TYPE_HASH, keccak256(NAME), keccak256(VERSION), block.chainid, address(this)));
+    }
+
+    function get() internal pure returns (Cache storage s) {
+        bytes32 position = _BORROW_PERMIT_STORAGE;
+        assembly {
+            s.slot := position
         }
     }
 }

--- a/contracts/vcnote/libraries/BorrowPermitParams.sol
+++ b/contracts/vcnote/libraries/BorrowPermitParams.sol
@@ -23,7 +23,7 @@ struct Cache {
 library BorrowPermitParamsLib {
     bytes32 private constant _BORROW_PERMIT_STORAGE = keccak256(abi.encode("vivacity.contracts.vcnote.libraries.BorrowPermitParams.Cache"));
 
-    bytes32 constant EIP721_TYPE_HASH =
+    bytes32 constant EIP712_TYPE_HASH =
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     bytes32 constant STRUCT_HASH =
         keccak256("Vivacity Borrow Permit(address executor,address borrower,address receiver,uint256 amount,uint256 deadline)");
@@ -73,7 +73,7 @@ library BorrowPermitParamsLib {
     }
 
     function _buildDomainSeparator() private view returns (bytes32) {
-        return keccak256(abi.encode(EIP721_TYPE_HASH, keccak256(NAME), keccak256(VERSION), block.chainid, address(this)));
+        return keccak256(abi.encode(EIP712_TYPE_HASH, keccak256(NAME), keccak256(VERSION), block.chainid, address(this)));
     }
 
     function get() internal pure returns (Cache storage s) {

--- a/contracts/vcnote/libraries/BorrowPermitParams.sol
+++ b/contracts/vcnote/libraries/BorrowPermitParams.sol
@@ -8,10 +8,9 @@ import {VCNoteStorage, VCNoteStorageLib} from "../storages/VCNoteStorage.sol";
 using BorrowPermitParamsLib for BorrowPermitParams global;
 
 struct BorrowPermitParams {
-    address executor;
+    address payable executor;
     address payable borrower;
-    address payable receiver;
-    uint256 borrowAmount;
+    uint256 borrowCNote;
     uint256 deadline;
     bytes signature;
 }
@@ -26,7 +25,7 @@ library BorrowPermitParamsLib {
     bytes32 constant EIP712_TYPE_HASH =
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     bytes32 constant STRUCT_HASH =
-        keccak256("Vivacity Borrow Permit(address executor,address borrower,address receiver,uint256 borrowAmount,uint256 deadline,uint256 nonce)");
+        keccak256("Vivacity Borrow Permit(address executor,address borrower,uint256 borrowCNote,uint256 deadline,uint256 nonce)");
     
     bytes private constant NAME = bytes("Vivacity Borrow Permit");
     bytes private constant VERSION = bytes("1");
@@ -41,16 +40,14 @@ library BorrowPermitParamsLib {
         if (msg.sender != params.executor) revert InvalidExecutor();
 
         if (params.borrower == address(0)) revert InvalidParams("borrower is zero address");
-        if (params.receiver == address(0)) revert InvalidParams("receiver is zero address");
-        if (params.borrowAmount == 0) revert InvalidParams("borrowAmount is zero");
+        if (params.borrowCNote == 0) revert InvalidParams("borrowCNote is zero");
         if (params.signature.length != 65) revert InvalidParams("invalid signature length");
 
         bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(
             STRUCT_HASH,
             params.executor,
             params.borrower,
-            params.receiver,
-            params.borrowAmount,
+            params.borrowCNote,
             params.deadline,
             VCNoteStorageLib.useNonce(params.borrower)
         )));

--- a/contracts/vcnote/libraries/BorrowPermitParams.sol
+++ b/contracts/vcnote/libraries/BorrowPermitParams.sol
@@ -26,8 +26,8 @@ library BorrowPermitParamsLib {
     bytes32 constant EIP712_TYPE_HASH =
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     bytes32 constant STRUCT_HASH =
-        keccak256("Vivacity Borrow Permit(address executor,address borrower,address receiver,uint256 amount,uint256 deadline)");
-
+        keccak256("Vivacity Borrow Permit(address executor,address borrower,address receiver,uint256 borrowAmount,uint256 deadline,uint256 nonce)");
+    
     bytes private constant NAME = bytes("Vivacity Borrow Permit");
     bytes private constant VERSION = bytes("1");
 
@@ -51,7 +51,8 @@ library BorrowPermitParamsLib {
             params.borrower,
             params.receiver,
             params.borrowAmount,
-            params.deadline
+            params.deadline,
+            VCNoteStorageLib.useNonce(params.borrower)
         )));
         if (params.borrower != ECDSA.recover(digest, params.signature)) {
             revert InvalidSignature();

--- a/scripts/deploy/canto-testnet/08_initialize_llama.ts
+++ b/scripts/deploy/canto-testnet/08_initialize_llama.ts
@@ -10,7 +10,7 @@ async function main({ deployed }: { deployed: DeployLocal }) {
   if (!deployed.llamaFramework?.llamaLens) throw "not found llamaLens";
 
   const DEPLOY_ROLE = 1;
-  const CORE_TEAM_ROLE = 1;
+  const CORE_TEAM_ROLE = 2;
 
   const core = await ethers.getContractAt("LlamaCore", deployed.llama.llamaCore);
   const policy = await ethers.getContractAt("LlamaPolicy", deployed.llama.llamaPolicy);


### PR DESCRIPTION
Changes,

1. To reduce complexity, instead of specifying a "receiver" as a parameter in the borrowPermit function, the "executor" automatically becomes a receiver.

2. Apply EIP712 to prevent confusion about signing when borrowing.

![Uploading Screen Shot 2023-11-15 at 11.27.18 PM.png…]()
